### PR TITLE
Trigger validation for empty arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ pnpm add @bombillazo/rhf-plus
 - [Form metadata](./docs/form-metadata.md)
 - [`ScrollIntoView` method on field refs](./docs/scroll-into-view-method.md)
 - [`Controller` children function](./docs/controller-children-function.md)
-- [Form focus data with `focusedField` and `isFocused`](./docs/focused-fields.md)
+- [Form and field `focus` states](./docs/focused-fields.md)
 
 Minor improvements:
 
-- [Add displayName to `useFormContext`](./docs/use-form-context-display-name.md)
+- [Empty array validation](./docs/empty-array-validation.md)
 - [Controller rules no longer stale on prop change](./docs/controller-rules-update.md)
+- [Add displayName to `useFormContext`](./docs/use-form-context-display-name.md)
 - [Improve `useController` error on missing `control` prop](./docs/improve-missing-use-controller-prop-error.md)
 
 ## Motive

--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -22,6 +22,7 @@ import ConditionalField from './conditionalField';
 import FormStateWithSchema from './formStateWithSchema';
 import SetValueWithSchema from './setValueWithSchema';
 import SetValueWithTrigger from './setValueWithTrigger';
+import EmptyArrayValidation from './emptyArrayValidation';
 import IsValid from './isValid';
 import Controller from './controller';
 import UseFieldArray from './useFieldArray';
@@ -152,6 +153,10 @@ const App = () => {
           element={<ControllerRulesUpdate />}
         />
         <Route path="/focused-fields" element={<FocusedFields />} />
+        <Route
+          path="/empty-array-validation"
+          element={<EmptyArrayValidation />}
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/app/src/emptyArrayValidation.tsx
+++ b/app/src/emptyArrayValidation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useRef } from 'react';
 import { useForm } from '@bombillazo/rhf-plus';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -27,9 +27,8 @@ type FormData = {
   };
 };
 
-let renderCounter = 0;
-
 const EmptyArrayValidation: React.FC = () => {
+  const renderCounter = useRef(0);
   const {
     register,
     setValue,
@@ -51,7 +50,7 @@ const EmptyArrayValidation: React.FC = () => {
     },
   });
 
-  renderCounter++;
+  renderCounter.current++;
 
   const clearItems = () => {
     setValue('items', [], { shouldValidate: true });
@@ -118,7 +117,7 @@ const EmptyArrayValidation: React.FC = () => {
       <button type="submit" id="submit">
         Submit
       </button>
-      <div id="renderCount">Render count: {renderCounter}</div>
+      <div id="renderCount">Render count: {renderCounter.current}</div>
     </form>
   );
 };

--- a/app/src/emptyArrayValidation.tsx
+++ b/app/src/emptyArrayValidation.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect } from 'react';
+import { useForm } from '@bombillazo/rhf-plus';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+const schema = yup.object({
+  items: yup.array().min(1, 'Items must have at least one item').required(),
+  nested: yup.object({
+    tags: yup.array().min(1, 'Tags must have at least one tag').required(),
+  }),
+  deep: yup.object({
+    level: yup.object({
+      values: yup.array().min(1, 'Values cannot be empty').required(),
+    }),
+  }),
+});
+
+type FormData = {
+  items: string[];
+  nested: {
+    tags: string[];
+  };
+  deep: {
+    level: {
+      values: string[];
+    };
+  };
+};
+
+let renderCounter = 0;
+
+const EmptyArrayValidation: React.FC = () => {
+  const {
+    register,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+    trigger,
+  } = useForm<FormData>({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      items: ['item1', 'item2'],
+      nested: {
+        tags: ['tag1', 'tag2'],
+      },
+      deep: {
+        level: {
+          values: ['value1', 'value2'],
+        },
+      },
+    },
+  });
+
+  renderCounter++;
+
+  const clearItems = () => {
+    setValue('items', [], { shouldValidate: true });
+  };
+
+  const clearTags = () => {
+    setValue('nested.tags', [], { shouldValidate: true });
+  };
+
+  const clearDeepValues = () => {
+    setValue('deep.level.values', [], { shouldValidate: true });
+  };
+
+  const setNewItems = () => {
+    setValue('items', ['new1', 'new2'], { shouldValidate: true });
+  };
+
+  const manualValidate = () => {
+    trigger();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(() => {})}>
+      <div>
+        <h3>Items Array</h3>
+        <input {...register('items.0')} placeholder="Item 0" />
+        <input {...register('items.1')} placeholder="Item 1" />
+        {errors.items && <p id="items-error">{errors.items.message}</p>}
+        <button type="button" id="clear-items" onClick={clearItems}>
+          Clear Items
+        </button>
+        <button type="button" id="set-items" onClick={setNewItems}>
+          Set New Items
+        </button>
+      </div>
+
+      <div>
+        <h3>Nested Tags Array</h3>
+        <input {...register('nested.tags.0')} placeholder="Tag 0" />
+        <input {...register('nested.tags.1')} placeholder="Tag 1" />
+        {errors.nested?.tags && (
+          <p id="tags-error">{errors.nested.tags.message}</p>
+        )}
+        <button type="button" id="clear-tags" onClick={clearTags}>
+          Clear Tags
+        </button>
+      </div>
+
+      <div>
+        <h3>Deep Nested Values Array</h3>
+        <input {...register('deep.level.values.0')} placeholder="Value 0" />
+        <input {...register('deep.level.values.1')} placeholder="Value 1" />
+        {errors.deep?.level?.values && (
+          <p id="deep-error">{errors.deep.level.values.message}</p>
+        )}
+        <button type="button" id="clear-deep" onClick={clearDeepValues}>
+          Clear Deep Values
+        </button>
+      </div>
+
+      <button type="button" id="validate" onClick={manualValidate}>
+        Validate All
+      </button>
+      <button type="submit" id="submit">
+        Submit
+      </button>
+      <div id="renderCount">Render count: {renderCounter}</div>
+    </form>
+  );
+};
+
+export default EmptyArrayValidation;

--- a/app/src/welcome/index.tsx
+++ b/app/src/welcome/index.tsx
@@ -286,6 +286,12 @@ const items: Item[] = [
     slugs: ['/focused-fields'],
     plus: true,
   },
+  {
+    title: 'EmptyArrayValidation',
+    description: 'Should trigger validation when setting empty array',
+    slugs: ['/empty-array-validation'],
+    plus: true,
+  },
 ];
 
 const Component: React.FC = () => {

--- a/cypress/e2e/setValueEmptyArray.cy.ts
+++ b/cypress/e2e/setValueEmptyArray.cy.ts
@@ -1,0 +1,79 @@
+describe('setValue empty array validation', () => {
+  it('should trigger validation when setting empty array with shouldValidate', () => {
+    cy.visit('http://localhost:3000/empty-array-validation');
+
+    // Initially, the arrays should have values and no errors
+    cy.get('input[name="items.0"]').should('have.value', 'item1');
+    cy.get('input[name="items.1"]').should('have.value', 'item2');
+    cy.get('#items-error').should('not.exist');
+
+    cy.get('input[name="nested.tags.0"]').should('have.value', 'tag1');
+    cy.get('input[name="nested.tags.1"]').should('have.value', 'tag2');
+    cy.get('#tags-error').should('not.exist');
+
+    cy.get('input[name="deep.level.values.0"]').should('have.value', 'value1');
+    cy.get('input[name="deep.level.values.1"]').should('have.value', 'value2');
+    cy.get('#deep-error').should('not.exist');
+
+    // Clear items array - should trigger validation error
+    cy.get('#clear-items').click();
+    cy.get('#items-error').should('exist');
+    cy.get('#items-error').should(
+      'contain',
+      'Items must have at least one item',
+    );
+    // When array is cleared, the existing inputs may retain their values but the array is empty
+    // The validation error is what's important here
+
+    // Clear nested tags array - should trigger validation error
+    cy.get('#clear-tags').click();
+    cy.get('#tags-error').should('exist');
+    cy.get('#tags-error').should('contain', 'Tags must have at least one tag');
+
+    // Clear deep nested values array - should trigger validation error
+    cy.get('#clear-deep').click();
+    cy.get('#deep-error').should('exist');
+    cy.get('#deep-error').should('contain', 'Values cannot be empty');
+
+    // Submit should not work with validation errors
+    cy.get('#submit').click();
+    cy.get('#items-error').should('exist');
+    cy.get('#tags-error').should('exist');
+    cy.get('#deep-error').should('exist');
+
+    // Set new items to clear the error
+    cy.get('#set-items').click();
+    cy.get('#items-error').should('not.exist');
+
+    // Manually add values to clear other errors
+    cy.get('input[name="nested.tags.0"]').type('newtag1');
+    cy.get('input[name="deep.level.values.0"]').type('newvalue1');
+
+    // Validate all should clear errors now
+    cy.get('#validate').click();
+    cy.get('#tags-error').should('not.exist');
+    cy.get('#deep-error').should('not.exist');
+  });
+
+  it('should immediately show validation errors when clearing arrays', () => {
+    cy.visit('http://localhost:3000/empty-array-validation');
+
+    // Clear all arrays in sequence
+    cy.get('#clear-items').click();
+    cy.get('#clear-tags').click();
+    cy.get('#clear-deep').click();
+
+    // All errors should be visible immediately
+    cy.get('#items-error').should('be.visible');
+    cy.get('#tags-error').should('be.visible');
+    cy.get('#deep-error').should('be.visible');
+
+    // Errors should have correct messages
+    cy.get('#items-error').should(
+      'contain',
+      'Items must have at least one item',
+    );
+    cy.get('#tags-error').should('contain', 'Tags must have at least one tag');
+    cy.get('#deep-error').should('contain', 'Values cannot be empty');
+  });
+});

--- a/docs/empty-array-validation.md
+++ b/docs/empty-array-validation.md
@@ -1,0 +1,74 @@
+# Empty Array Validation
+
+## Overview
+
+This ensures that array fields with validation rules (like minimum length requirements) are properly validated when their values are cleared.
+
+## Problem
+
+Previously, when using `setValue` to set an empty array with `shouldValidate: true`, validation would not be triggered. This meant that validation errors for required array fields or arrays with minimum length requirements would not appear until the form was submitted or validation was manually triggered.
+
+```typescript
+// This would NOT trigger validation in previous versions
+setValue('items', [], { shouldValidate: true });
+```
+
+## Solution
+
+The fix ensures that validation is properly triggered for all array fields when `shouldValidate` is set to `true`, including:
+
+- Field arrays
+- Empty arrays
+- Nested array fields
+- Deeply nested array structures
+
+## Usage
+
+### Basic Example
+
+```typescript
+import { useForm } from '@bombillazo/rhf-plus';
+
+const MyForm = () => {
+  const { setValue, formState: { errors } } = useForm({
+    defaultValues: {
+      items: ['item1', 'item2']
+    }
+  });
+
+  const clearItems = () => {
+    // This will now properly trigger validation
+    setValue('items', [], { shouldValidate: true });
+  };
+
+  return (
+    <form>
+      {/* Your form fields */}
+      {errors.items && <span>Items cannot be empty</span>}
+      <button type="button" onClick={clearItems}>Clear Items</button>
+    </form>
+  );
+};
+```
+
+## Benefits
+
+1. **Immediate Feedback**: Users get immediate validation feedback when clearing array fields
+2. **Consistent Behavior**: Arrays behave consistently with other field types when using `shouldValidate`
+3. **Better UX**: Validation errors appear as soon as the array is cleared, not just on form submission
+4. **Schema Integration**: Works seamlessly with schema validation libraries like Yup, Zod, etc.
+
+## Migration Guide
+
+No breaking changes are introduced with this fix. Existing code will continue to work as before, but will now properly trigger validation for empty arrays when `shouldValidate: true` is specified.
+
+If you were previously working around this issue by manually calling `trigger()` after setting empty arrays, you can now remove that workaround:
+
+```typescript
+// Before (workaround)
+setValue('items', []);
+trigger('items'); // Manual trigger was needed
+
+// After (fixed)
+setValue('items', [], { shouldValidate: true }); // Validation triggers automatically
+```

--- a/src/__tests__/useForm/setValueEmptyArray.test.tsx
+++ b/src/__tests__/useForm/setValueEmptyArray.test.tsx
@@ -1,0 +1,173 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useForm } from '../../useForm';
+
+describe('setValue with empty array validation', () => {
+  it('should trigger validation when setting empty array with shouldValidate', async () => {
+    const { result } = renderHook(() =>
+      useForm({
+        defaultValues: {
+          items: [{ name: 'item1' }, { name: 'item2' }],
+        },
+        mode: 'onChange',
+        resolver: (values) => {
+          // Custom resolver to validate that items array is not empty
+          if (!values.items || values.items.length === 0) {
+            return {
+              values: {},
+              errors: {
+                items: {
+                  type: 'required',
+                  message: 'Items cannot be empty',
+                },
+              },
+            };
+          }
+          return { values, errors: {} };
+        },
+      }),
+    );
+
+    // Initially there should be no errors
+    expect(result.current.formState.errors.items).toBeUndefined();
+
+    await act(async () => {
+      result.current.setValue('items', [], { shouldValidate: true });
+    });
+
+    // After setting empty array with shouldValidate, there should be an error
+    expect(result.current.formState.errors.items).toEqual({
+      type: 'required',
+      message: 'Items cannot be empty',
+    });
+  });
+
+  it('should trigger validation for nested field when setting empty array with shouldValidate', async () => {
+    const { result } = renderHook(() =>
+      useForm({
+        defaultValues: {
+          user: {
+            tags: ['tag1', 'tag2'],
+          },
+        },
+        mode: 'onChange',
+        resolver: (values) => {
+          if (!values.user?.tags || values.user.tags.length === 0) {
+            return {
+              values: {},
+              errors: {
+                user: {
+                  tags: {
+                    type: 'required',
+                    message: 'Tags cannot be empty',
+                  },
+                },
+              },
+            };
+          }
+          return { values, errors: {} };
+        },
+      }),
+    );
+
+    expect(result.current.formState.errors.user?.tags).toBeUndefined();
+
+    await act(async () => {
+      result.current.setValue('user.tags', [], { shouldValidate: true });
+    });
+
+    expect(result.current.formState.errors.user?.tags).toEqual({
+      type: 'required',
+      message: 'Tags cannot be empty',
+    });
+  });
+
+  it('should trigger validation with async resolver when setting empty array', async () => {
+    const resolver = jest.fn(async (values) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      if (!values.items || values.items.length === 0) {
+        return {
+          values: {},
+          errors: {
+            items: {
+              message: 'Items cannot be empty',
+              type: 'required',
+            },
+          },
+        };
+      }
+      return { values, errors: {} };
+    });
+
+    const { result } = renderHook(() =>
+      useForm({
+        defaultValues: {
+          items: [{ name: 'item1' }],
+        },
+        resolver,
+      }),
+    );
+
+    expect(result.current.formState.errors.items).toBeUndefined();
+
+    await act(async () => {
+      result.current.setValue('items', [], { shouldValidate: true });
+      // Wait for async validation to complete
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(resolver).toHaveBeenCalled();
+    expect(result.current.formState.errors.items).toEqual({
+      message: 'Items cannot be empty',
+      type: 'required',
+    });
+  });
+
+  it('should trigger validation for deeply nested array field', async () => {
+    const { result } = renderHook(() =>
+      useForm({
+        defaultValues: {
+          data: {
+            nested: {
+              items: ['item1', 'item2'],
+            },
+          },
+        },
+        resolver: (values) => {
+          if (
+            !values.data?.nested?.items ||
+            values.data.nested.items.length === 0
+          ) {
+            return {
+              values: {},
+              errors: {
+                data: {
+                  nested: {
+                    items: {
+                      type: 'required',
+                      message: 'Nested items cannot be empty',
+                    },
+                  },
+                },
+              },
+            };
+          }
+          return { values, errors: {} };
+        },
+      }),
+    );
+
+    expect(result.current.formState.errors.data?.nested?.items).toBeUndefined();
+
+    await act(async () => {
+      result.current.setValue('data.nested.items', [], {
+        shouldValidate: true,
+      });
+    });
+
+    expect(result.current.formState.errors.data?.nested?.items).toEqual({
+      type: 'required',
+      message: 'Nested items cannot be empty',
+    });
+  });
+});

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -768,6 +768,15 @@ export function createFormControl<
       name: _state.mount ? name : undefined,
       values: cloneObject(_formValues),
     });
+
+    // Trigger validation when shouldValidate is true
+    // This ensures validation happens for all cases including:
+    // - Field arrays
+    // - Empty arrays
+    // - Nested fields with array values
+    if (options.shouldValidate) {
+      trigger(name as Path<TFieldValues>);
+    }
   };
 
   const onChange: ChangeHandler = async (event) => {


### PR DESCRIPTION
 Resolves #30

  ## Summary

  - Fixed `setValue` to properly trigger validation when setting empty arrays with `shouldValidate: true`
  - Added comprehensive unit tests for various array nesting levels
  - Created interactive demo app and E2E tests
  - Added documentation for the feature