### PR TITLE
Fix conflicting form name with special DOM form props

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1473,7 +1473,7 @@ export function createFormControl<
               if (isHTMLElement(fieldReference)) {
                 const form = fieldReference.closest('form');
                 if (form) {
-                  form.reset();
+                  HTMLFormElement.prototype.reset.call(form);
                   break;
                 }
               }


### PR DESCRIPTION
In HTML, if you give a form control element (like <input>, <button>, <select>) a name or id that matches a property of the form element, the browser creates a direct property on the form object with that name. That’s why sometimes fieldReference.closest('form') gives you a form whose .reset is a native function (normal case), and sometimes it gives you a button element (when a child element with name="reset" overrides the property). We can solve this using an HTML safety method.