### PR TITLE
Add `shouldSkipReadOnlyValidation` flag for readonly field validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ pnpm add @bombillazo/rhf-plus
 - [Form and field `focus` state](./docs/focused-fields.md)
 - [Form `isDirtySinceSubmit` state](./docs/is-dirty-since-submit.md)
 - [Form `hasBeenSubmitted` state](./docs/has-been-submitted.md)
+- [Readonly field validation skip](./docs/readonly-validation-skip.md)
 
 Minor improvements:
 

--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -52,6 +52,7 @@ import MetadataControl from './metadata-control';
 import JsxErrorMessages from './jsxErrorMessages';
 import ScrollIntoView from './scrollIntoView';
 import SmartDisabled from './smartDisabled';
+import ReadonlyValidation from './readonlyValidation';
 import ControllerRulesUpdate from './controllerRulesUpdate';
 import FocusedFields from './focusedFields';
 import IsDirtySinceSubmit from './isDirtySinceSubmit';
@@ -149,6 +150,7 @@ const App = () => {
         <Route path="/jsx-error-messages" element={<JsxErrorMessages />} />
         <Route path="/scroll-into-view" element={<ScrollIntoView />} />
         <Route path="/smart-disabled" element={<SmartDisabled />} />
+        <Route path="/readonly-validation" element={<ReadonlyValidation />} />
         <Route
           path="/controller-rules-update"
           element={<ControllerRulesUpdate />}

--- a/app/src/readonlyValidation.tsx
+++ b/app/src/readonlyValidation.tsx
@@ -1,0 +1,324 @@
+import React, { useState } from 'react';
+import { useForm, type FieldErrors } from '@bombillazo/rhf-plus';
+
+type FormData = {
+  readonlyField: string;
+  normalField: string;
+  readonlyRequired: string;
+  readonlyPattern: string;
+  readonlyMinLength: string;
+  readonlyCustom: string;
+};
+
+const ReadonlyValidation = () => {
+  const [isReadonlyMode, setIsReadonlyMode] = useState(true);
+  const [shouldSkipReadOnlyValidation, setShouldSkipReadOnlyValidation] =
+    useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+    trigger,
+    setValue,
+    getValues,
+    watch,
+    control,
+  } = useForm<FormData>({
+    defaultValues: {
+      readonlyField: '', // Empty so it fails required validation
+      normalField: '',
+      readonlyRequired: '',
+      readonlyPattern: 'invalid-pattern',
+      readonlyMinLength: 'ab',
+      readonlyCustom: 'fail',
+    },
+    shouldSkipReadOnlyValidation,
+  });
+
+  // Handle flag changes and readonly mode changes
+  React.useEffect(() => {
+    // When readonly mode changes, we need to update the tracking
+    // because DOM readonly attributes have changed
+    control._updateReadonlyFieldTracking();
+    // Re-trigger validation to apply new behavior
+    trigger();
+  }, [shouldSkipReadOnlyValidation, isReadonlyMode, control, trigger]);
+
+  const onSubmit = (data: FormData) => {
+    console.log('Form submitted:', data);
+  };
+
+  const onInvalid = (errors: FieldErrors<FormData>) => {
+    console.log('Form validation failed:', errors);
+  };
+
+  const customValidator = (value: string) => {
+    return value === 'fail' ? 'Custom validation error' : true;
+  };
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>Readonly Field Validation Test</h1>
+
+      <div style={{ marginBottom: '20px', padding: '10px' }}>
+        <h2>Configuration Toggles</h2>
+
+        <div style={{ marginBottom: '10px' }}>
+          <button
+            type="button"
+            onClick={() => setIsReadonlyMode(!isReadonlyMode)}
+            data-testid="toggle-readonly-mode"
+            style={{ marginRight: '10px', padding: '8px 16px' }}
+          >
+            {isReadonlyMode ? 'Disable Readonly' : 'Enable Readonly'}
+          </button>
+          <span data-testid="readonly-mode-status">
+            Fields Mode: {isReadonlyMode ? '🔒 READONLY' : '✏️ EDITABLE'}
+          </span>
+        </div>
+
+        <div style={{ marginBottom: '10px' }}>
+          <button
+            type="button"
+            onClick={() =>
+              setShouldSkipReadOnlyValidation(!shouldSkipReadOnlyValidation)
+            }
+            data-testid="toggle-skip-validation-flag"
+            style={{ marginRight: '10px', padding: '8px 16px' }}
+          >
+            {shouldSkipReadOnlyValidation
+              ? 'Disable Skip Flag'
+              : 'Enable Skip Flag'}
+          </button>
+          <span data-testid="skip-validation-flag-status">
+            shouldSkipReadOnlyValidation:{' '}
+            {shouldSkipReadOnlyValidation ? '✅ TRUE' : '❌ FALSE'}
+          </span>
+        </div>
+
+        <div
+          style={{
+            padding: '10px',
+            backgroundColor: '#f5f5f5',
+            borderRadius: '4px',
+            fontSize: '14px',
+            color: '#666',
+          }}
+        >
+          <strong>Expected Behavior:</strong>
+          <br />
+          Readonly fields should{' '}
+          {shouldSkipReadOnlyValidation && isReadonlyMode
+            ? 'NOT validate (new behavior)'
+            : 'validate normally' +
+              (isReadonlyMode && !shouldSkipReadOnlyValidation
+                ? ' (backwards compatible)'
+                : '')}
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+        <div style={{ marginBottom: '20px' }}>
+          <h2>Basic Readonly Field</h2>
+          <label>
+            Toggleable Readonly Field (should{' '}
+            {isReadonlyMode && shouldSkipReadOnlyValidation ? 'not ' : ''}
+            validate):
+            {isReadonlyMode ? '🔒' : '✏️'}
+            <input
+              {...register('readonlyField', { required: 'Required' })}
+              readOnly={isReadonlyMode}
+              data-testid="readonly-field"
+              style={{ marginLeft: '10px', width: '200px' }}
+            />
+          </label>
+          {errors.readonlyField && (
+            <div data-testid="readonly-field-error" style={{ color: 'red' }}>
+              {String(errors.readonlyField.message)}
+            </div>
+          )}
+        </div>
+
+        <div style={{ marginBottom: '20px' }}>
+          <label>
+            Normal Field (should validate):
+            <input
+              {...register('normalField', { required: 'Required' })}
+              data-testid="normal-field"
+              style={{ marginLeft: '10px', width: '200px' }}
+            />
+          </label>
+          {errors.normalField && (
+            <div data-testid="normal-field-error" style={{ color: 'red' }}>
+              {String(errors.normalField.message)}
+            </div>
+          )}
+        </div>
+
+        <div style={{ marginBottom: '20px' }}>
+          <h2>Dynamic Validation Rules</h2>
+
+          <div style={{ marginBottom: '10px' }}>
+            <label>
+              Required (empty, should{' '}
+              {isReadonlyMode && shouldSkipReadOnlyValidation ? 'not ' : ''}
+              validate):
+              {isReadonlyMode ? '🔒' : '✏️'}
+              <input
+                {...register('readonlyRequired', { required: 'Required' })}
+                readOnly={isReadonlyMode}
+                data-testid="readonly-required"
+                style={{ marginLeft: '10px', width: '200px' }}
+              />
+            </label>
+            {errors.readonlyRequired && (
+              <div
+                data-testid="readonly-required-error"
+                style={{ color: 'red' }}
+              >
+                {String(errors.readonlyRequired.message)}
+              </div>
+            )}
+          </div>
+
+          <div style={{ marginBottom: '10px' }}>
+            <label>
+              Pattern (invalid pattern, should{' '}
+              {isReadonlyMode && shouldSkipReadOnlyValidation ? 'not ' : ''}
+              validate):
+              {isReadonlyMode ? '🔒' : '✏️'}
+              <input
+                {...register('readonlyPattern', {
+                  pattern: { value: /^[A-Z]+$/, message: 'Must be uppercase' },
+                })}
+                readOnly={isReadonlyMode}
+                data-testid="readonly-pattern"
+                style={{ marginLeft: '10px', width: '200px' }}
+              />
+            </label>
+            {errors.readonlyPattern && (
+              <div
+                data-testid="readonly-pattern-error"
+                style={{ color: 'red' }}
+              >
+                {String(errors.readonlyPattern.message)}
+              </div>
+            )}
+          </div>
+
+          <div style={{ marginBottom: '10px' }}>
+            <label>
+              MinLength (too short, should{' '}
+              {isReadonlyMode && shouldSkipReadOnlyValidation ? 'not ' : ''}
+              validate):
+              {isReadonlyMode ? '🔒' : '✏️'}
+              <input
+                {...register('readonlyMinLength', {
+                  minLength: { value: 5, message: 'Minimum 5 characters' },
+                })}
+                readOnly={isReadonlyMode}
+                data-testid="readonly-minlength"
+                style={{ marginLeft: '10px', width: '200px' }}
+              />
+            </label>
+            {errors.readonlyMinLength && (
+              <div
+                data-testid="readonly-minlength-error"
+                style={{ color: 'red' }}
+              >
+                {String(errors.readonlyMinLength.message)}
+              </div>
+            )}
+          </div>
+
+          <div style={{ marginBottom: '10px' }}>
+            <label>
+              Custom Validation (should fail, but{' '}
+              {isReadonlyMode && shouldSkipReadOnlyValidation ? 'not ' : ''}
+              validate):
+              {isReadonlyMode ? '🔒' : '✏️'}
+              <input
+                {...register('readonlyCustom', {
+                  validate: customValidator,
+                })}
+                readOnly={isReadonlyMode}
+                data-testid="readonly-custom"
+                style={{ marginLeft: '10px', width: '200px' }}
+              />
+            </label>
+            {errors.readonlyCustom && (
+              <div data-testid="readonly-custom-error" style={{ color: 'red' }}>
+                {String(errors.readonlyCustom.message)}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div style={{ marginBottom: '20px' }}>
+          <h2>Form Actions</h2>
+          <button
+            type="submit"
+            data-testid="submit-button"
+            style={{ marginRight: '10px' }}
+          >
+            Submit
+          </button>
+
+          <button
+            type="button"
+            onClick={() => trigger()}
+            data-testid="trigger-validation"
+            style={{ marginRight: '10px' }}
+          >
+            Trigger Validation
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setValue('readonlyField', 'new-value')}
+            data-testid="set-readonly-value"
+            style={{ marginRight: '10px' }}
+          >
+            Set Readonly Value
+          </button>
+        </div>
+
+        <div style={{ marginBottom: '20px' }}>
+          <h2>Form State</h2>
+          <div data-testid="readonly-mode">
+            Readonly Mode: {String(isReadonlyMode)}
+          </div>
+          <div data-testid="skip-validation-flag">
+            shouldSkipReadOnlyValidation: {String(shouldSkipReadOnlyValidation)}
+          </div>
+          <div data-testid="form-valid">Is Valid: {String(isValid)}</div>
+          <div data-testid="form-errors">
+            Errors:{' '}
+            {JSON.stringify(
+              errors,
+              (_, value) => {
+                // Filter out DOM elements and other non-serializable values
+                if (
+                  value &&
+                  typeof value === 'object' &&
+                  value.constructor &&
+                  value.constructor.name === 'HTMLInputElement'
+                ) {
+                  return '[HTMLInputElement]';
+                }
+                return value;
+              },
+              2,
+            )}
+          </div>
+          <div data-testid="form-values">
+            Values: {JSON.stringify(watch(), null, 2)}
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default ReadonlyValidation;

--- a/app/src/welcome/index.tsx
+++ b/app/src/welcome/index.tsx
@@ -298,6 +298,13 @@ const items: Item[] = [
     slugs: ['/is-dirty-since-submit'],
     plus: true,
   },
+  {
+    title: 'ReadonlyValidation',
+    description:
+      'Should skip validation for readonly fields while maintaining form functionality',
+    slugs: ['/readonly-validation'],
+    plus: true,
+  },
 ];
 
 const Component: React.FC = () => {

--- a/cypress/e2e/readonlyValidation.cy.ts
+++ b/cypress/e2e/readonlyValidation.cy.ts
@@ -1,0 +1,522 @@
+describe('Readonly Field Validation', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/readonly-validation');
+  });
+
+  describe('Basic readonly field behavior (backwards compatible)', () => {
+    it('should validate readonly fields when flag is disabled (default)', () => {
+      // Ensure flag is OFF (initial state)
+      cy.get('[data-testid="skip-validation-flag-status"]').should(
+        'contain',
+        'FALSE',
+      );
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'READONLY',
+      );
+
+      // Submit form with empty required fields
+      cy.get('[data-testid="submit-button"]').click();
+
+      // Both readonly and normal fields should show validation errors
+      cy.get('[data-testid="readonly-field-error"]').should('be.visible');
+      cy.get('[data-testid="readonly-required-error"]').should('be.visible');
+      cy.get('[data-testid="normal-field-error"]').should('be.visible');
+
+      // Form should be invalid
+      cy.get('[data-testid="form-valid"]').should('contain', 'false');
+    });
+
+    it('should validate normal fields alongside readonly fields', () => {
+      // Fill in the normal field only
+      cy.get('[data-testid="normal-field"]').type('test value');
+
+      // Submit form
+      cy.get('[data-testid="submit-button"]').click();
+
+      // Normal field should not show error
+      cy.get('[data-testid="normal-field-error"]').should('not.exist');
+      // But readonly fields should show errors (backwards compatible)
+      cy.get('[data-testid="readonly-field-error"]').should('be.visible');
+    });
+
+    it('should handle complex validation rules on readonly fields', () => {
+      // Verify readonly fields have invalid data
+      cy.get('[data-testid="readonly-pattern"]').should(
+        'have.value',
+        'invalid-pattern',
+      );
+      cy.get('[data-testid="readonly-minlength"]').should('have.value', 'ab');
+      cy.get('[data-testid="readonly-custom"]').should('have.value', 'fail');
+
+      // Submit form
+      cy.get('[data-testid="submit-button"]').click();
+
+      // All readonly fields should show validation errors (backwards compatible)
+      cy.get('[data-testid="readonly-pattern-error"]').should('be.visible');
+      cy.get('[data-testid="readonly-minlength-error"]').should('be.visible');
+      cy.get('[data-testid="readonly-custom-error"]').should('be.visible');
+    });
+  });
+
+  describe('Toggle behavior', () => {
+    it('should start in readonly mode by default', () => {
+      // Verify initial state
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'READONLY',
+      );
+      cy.get('[data-testid="readonly-mode"]').should('contain', 'true');
+      cy.get('[data-testid="toggle-readonly-mode"]').should(
+        'contain',
+        'Disable Readonly',
+      );
+
+      // Verify fields are readonly
+      cy.get('[data-testid="readonly-field"]').should('have.attr', 'readonly');
+      cy.get('[data-testid="readonly-required"]').should(
+        'have.attr',
+        'readonly',
+      );
+      cy.get('[data-testid="readonly-pattern"]').should(
+        'have.attr',
+        'readonly',
+      );
+    });
+
+    it('should toggle to editable mode when button is clicked', () => {
+      // Click toggle button
+      cy.get('[data-testid="toggle-readonly-mode"]').click();
+
+      // Verify state changed to editable
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'EDITABLE',
+      );
+      cy.get('[data-testid="readonly-mode"]').should('contain', 'false');
+      cy.get('[data-testid="toggle-readonly-mode"]').should(
+        'contain',
+        'Enable Readonly',
+      );
+
+      // Verify fields are no longer readonly
+      cy.get('[data-testid="readonly-field"]').should(
+        'not.have.attr',
+        'readonly',
+      );
+      cy.get('[data-testid="readonly-required"]').should(
+        'not.have.attr',
+        'readonly',
+      );
+      cy.get('[data-testid="readonly-pattern"]').should(
+        'not.have.attr',
+        'readonly',
+      );
+    });
+
+    it('should toggle back to readonly mode', () => {
+      // Start in readonly, toggle to editable, then back to readonly
+      cy.get('[data-testid="toggle-readonly-mode"]').click(); // to editable
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'EDITABLE',
+      );
+
+      cy.get('[data-testid="toggle-readonly-mode"]').click(); // back to readonly
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'READONLY',
+      );
+      cy.get('[data-testid="readonly-mode"]').should('contain', 'true');
+
+      // Verify fields are readonly again
+      cy.get('[data-testid="readonly-field"]').should('have.attr', 'readonly');
+    });
+  });
+
+  describe('Flag toggle behavior', () => {
+    it('should start with flag disabled by default', () => {
+      // Verify initial flag state
+      cy.get('[data-testid="skip-validation-flag-status"]').should(
+        'contain',
+        'FALSE',
+      );
+      cy.get('[data-testid="skip-validation-flag"]').should('contain', 'false');
+      cy.get('[data-testid="toggle-skip-validation-flag"]').should(
+        'contain',
+        'Enable Skip Flag',
+      );
+    });
+
+    it('should toggle the flag when button is clicked', () => {
+      // Click toggle button
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Verify flag state changed
+      cy.get('[data-testid="skip-validation-flag-status"]').should(
+        'contain',
+        'TRUE',
+      );
+      cy.get('[data-testid="skip-validation-flag"]').should('contain', 'true');
+      cy.get('[data-testid="toggle-skip-validation-flag"]').should(
+        'contain',
+        'Disable Skip Flag',
+      );
+
+      // Toggle back
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+      cy.get('[data-testid="skip-validation-flag-status"]').should(
+        'contain',
+        'FALSE',
+      );
+    });
+  });
+
+  describe('Dynamic readonly validation with shouldSkipReadOnlyValidation flag', () => {
+    it('should skip readonly validation when flag is enabled', () => {
+      // Enable the flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+      cy.get('[data-testid="skip-validation-flag-status"]').should(
+        'contain',
+        'TRUE',
+      );
+
+      // Ensure fields are readonly
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'READONLY',
+      );
+
+      // Submit form with empty required fields
+      cy.get('[data-testid="submit-button"]').click();
+
+      // Readonly fields should NOT show validation errors
+      cy.get('[data-testid="readonly-field-error"]').should('not.exist');
+      cy.get('[data-testid="readonly-required-error"]').should('not.exist');
+
+      // But normal field should still show error
+      cy.get('[data-testid="normal-field-error"]').should('be.visible');
+
+      // Form should be invalid due to normal field
+      cy.get('[data-testid="form-valid"]').should('contain', 'false');
+    });
+
+    it('should validate all fields when flag is enabled but fields are not readonly', () => {
+      // Enable the flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Disable readonly mode (make fields editable)
+      cy.get('[data-testid="toggle-readonly-mode"]').click();
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'EDITABLE',
+      );
+
+      // Submit form with empty required fields
+      cy.get('[data-testid="submit-button"]').click();
+
+      // All fields should show validation errors since they're not readonly
+      cy.get('[data-testid="readonly-field-error"]').should('be.visible');
+      cy.get('[data-testid="readonly-required-error"]').should('be.visible');
+      cy.get('[data-testid="normal-field-error"]').should('be.visible');
+    });
+
+    it('should maintain validation state when toggling flag', () => {
+      // Start with flag OFF, readonly ON - submit to get errors
+      cy.get('[data-testid="submit-button"]').click();
+      cy.get('[data-testid="readonly-field-error"]').should('be.visible');
+
+      // Enable the flag - readonly field error should disappear
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+      cy.get('[data-testid="trigger-validation"]').click();
+      cy.get('[data-testid="readonly-field-error"]').should('not.exist');
+
+      // Disable the flag - readonly field error should reappear
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+      cy.get('[data-testid="trigger-validation"]').click();
+      cy.get('[data-testid="readonly-field-error"]').should('be.visible');
+    });
+  });
+
+  describe('Validation behavior with toggle', () => {
+    it('should validate when in editable mode', () => {
+      // Switch to editable mode
+      cy.get('[data-testid="toggle-readonly-mode"]').click();
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'EDITABLE',
+      );
+
+      // Submit form (fields are empty and required)
+      cy.get('[data-testid="submit-button"]').click();
+
+      // Should show validation errors now that fields are editable
+      cy.get('[data-testid="readonly-field-error"]').should('be.visible');
+      cy.get('[data-testid="readonly-required-error"]').should('be.visible');
+      cy.get('[data-testid="normal-field-error"]').should('be.visible');
+
+      // Form should be invalid
+      cy.get('[data-testid="form-valid"]').should('contain', 'false');
+    });
+
+    it('should skip validation when in readonly mode (with flag enabled)', () => {
+      // Enable the skip validation flag first
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+      cy.get('[data-testid="skip-validation-flag-status"]').should(
+        'contain',
+        'TRUE',
+      );
+
+      // Ensure we're in readonly mode
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'READONLY',
+      );
+
+      // Submit form
+      cy.get('[data-testid="submit-button"]').click();
+
+      // Readonly fields should not show validation errors
+      cy.get('[data-testid="readonly-field-error"]').should('not.exist');
+      cy.get('[data-testid="readonly-required-error"]').should('not.exist');
+
+      // But normal field should still show error
+      cy.get('[data-testid="normal-field-error"]').should('be.visible');
+    });
+
+    it('should maintain validation state when toggling modes (with flag enabled)', () => {
+      // Enable the skip validation flag first
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+      cy.get('[data-testid="skip-validation-flag-status"]').should(
+        'contain',
+        'TRUE',
+      );
+
+      // Start in readonly mode and submit (should not show readonly field errors)
+      cy.get('[data-testid="submit-button"]').click();
+      cy.get('[data-testid="readonly-field-error"]').should('not.exist');
+
+      // Toggle to editable mode
+      cy.get('[data-testid="toggle-readonly-mode"]').click();
+
+      // Trigger validation manually
+      cy.get('[data-testid="trigger-validation"]').click();
+
+      // Now should show validation errors for previously readonly fields
+      cy.get('[data-testid="readonly-field-error"]').should('be.visible');
+      cy.get('[data-testid="readonly-required-error"]').should('be.visible');
+
+      // Toggle back to readonly mode
+      cy.get('[data-testid="toggle-readonly-mode"]').click();
+
+      // Trigger validation again
+      cy.get('[data-testid="trigger-validation"]').click();
+
+      // Validation errors should be gone for readonly fields
+      cy.get('[data-testid="readonly-field-error"]').should('not.exist');
+      cy.get('[data-testid="readonly-required-error"]').should('not.exist');
+    });
+  });
+
+  describe('Form state and value management', () => {
+    it('should include readonly fields in form values', () => {
+      // Enable skip validation flag to test current behavior
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Check that readonly field values are included in form state
+      cy.get('[data-testid="form-values"]').should(
+        'contain',
+        'invalid-pattern',
+      );
+      cy.get('[data-testid="form-values"]').should('contain', 'ab');
+      cy.get('[data-testid="form-values"]').should('contain', 'fail');
+    });
+
+    it('should allow programmatic updates to readonly field values', () => {
+      // Set new value programmatically
+      cy.get('[data-testid="set-readonly-value"]').click();
+
+      // Verify the value was updated
+      cy.get('[data-testid="readonly-field"]').should(
+        'have.value',
+        'new-value',
+      );
+
+      // Verify form values reflect the change
+      cy.get('[data-testid="form-values"]').should('contain', 'new-value');
+    });
+
+    it('should not trigger validation errors when readonly fields are updated programmatically', () => {
+      // Enable skip validation flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Set new value programmatically
+      cy.get('[data-testid="set-readonly-value"]').click();
+
+      // Trigger validation
+      cy.get('[data-testid="trigger-validation"]').click();
+
+      // Readonly field should not show any validation errors
+      cy.get('[data-testid="readonly-field-error"]').should('not.exist');
+    });
+  });
+
+  describe('Form submission with readonly fields', () => {
+    it('should submit successfully when all validation passes (ignoring readonly fields)', () => {
+      // Enable skip validation flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Fill in valid data for normal field
+      cy.get('[data-testid="normal-field"]').type('valid input');
+
+      // Submit form
+      cy.get('[data-testid="submit-button"]').click();
+
+      // Form should be valid despite readonly fields having invalid data
+      cy.get('[data-testid="form-valid"]').should('contain', 'true');
+
+      // No errors should be displayed
+      cy.get('[data-testid="form-errors"]').should('contain', '{}');
+    });
+
+    it('should include readonly field values in submitted data', () => {
+      // Enable skip validation flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Fill normal field
+      cy.get('[data-testid="normal-field"]').type('test input');
+
+      // Submit form and check values include readonly fields
+      cy.get('[data-testid="submit-button"]').click();
+
+      // Verify readonly values are present in form data
+      cy.get('[data-testid="form-values"]').should(
+        'contain',
+        'invalid-pattern',
+      );
+      cy.get('[data-testid="form-values"]').should('contain', 'test input');
+    });
+  });
+
+  describe('Integration with other form features', () => {
+    it('should work correctly alongside regular field validation', () => {
+      // Enable skip validation flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Leave normal field empty (should trigger validation)
+      // Submit form
+      cy.get('[data-testid="submit-button"]').click();
+
+      // Normal field should show error
+      cy.get('[data-testid="normal-field-error"]').should('be.visible');
+
+      // Readonly fields should not show errors
+      cy.get('[data-testid="readonly-field-error"]').should('not.exist');
+      cy.get('[data-testid="readonly-required-error"]').should('not.exist');
+
+      // Form should be invalid due to normal field
+      cy.get('[data-testid="form-valid"]').should('contain', 'false');
+    });
+
+    it('should maintain readonly behavior across multiple interactions', () => {
+      // Enable skip validation flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Multiple form operations
+      cy.get('[data-testid="trigger-validation"]').click();
+      cy.get('[data-testid="normal-field"]').type('test');
+      cy.get('[data-testid="trigger-validation"]').click();
+      cy.get('[data-testid="submit-button"]').click();
+      cy.get('[data-testid="set-readonly-value"]').click();
+      cy.get('[data-testid="trigger-validation"]').click();
+
+      // Readonly fields should never show validation errors
+      cy.get('[data-testid="readonly-field-error"]').should('not.exist');
+      cy.get('[data-testid="readonly-required-error"]').should('not.exist');
+      cy.get('[data-testid="readonly-pattern-error"]').should('not.exist');
+      cy.get('[data-testid="readonly-minlength-error"]').should('not.exist');
+      cy.get('[data-testid="readonly-custom-error"]').should('not.exist');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle readonly fields with no initial value when flag is enabled', () => {
+      // Enable skip validation flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Readonly required field has no value but should not validate
+      cy.get('[data-testid="readonly-required"]').should('have.value', '');
+      cy.get('[data-testid="submit-button"]').click();
+      cy.get('[data-testid="readonly-required-error"]').should('not.exist');
+    });
+
+    it('should handle readonly fields with complex validation chains when flag is enabled', () => {
+      // Enable skip validation flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Custom validation field should not validate even with complex rules
+      cy.get('[data-testid="readonly-custom"]').should('have.value', 'fail');
+      cy.get('[data-testid="trigger-validation"]').click();
+      cy.get('[data-testid="readonly-custom-error"]').should('not.exist');
+    });
+
+    it('should maintain consistent behavior after rapid interactions', () => {
+      // Enable skip validation flag
+      cy.get('[data-testid="toggle-skip-validation-flag"]').click();
+
+      // Rapid fire interactions
+      for (let i = 0; i < 5; i++) {
+        cy.get('[data-testid="trigger-validation"]').click();
+        cy.get('[data-testid="set-readonly-value"]').click();
+      }
+
+      // Should still maintain readonly validation skip behavior
+      cy.get('[data-testid="submit-button"]').click();
+      cy.get('[data-testid="readonly-field-error"]').should('not.exist');
+    });
+  });
+
+  describe('Field interaction', () => {
+    it('should allow typing when in editable mode', () => {
+      // Switch to editable mode
+      cy.get('[data-testid="toggle-readonly-mode"]').click();
+
+      // Should be able to type in the field
+      cy.get('[data-testid="readonly-field"]').clear().type('user input');
+      cy.get('[data-testid="readonly-field"]').should(
+        'have.value',
+        'user input',
+      );
+
+      // Form values should update
+      cy.get('[data-testid="form-values"]').should('contain', 'user input');
+    });
+
+    it('should prevent typing when in readonly mode', () => {
+      // Ensure we're in readonly mode
+      cy.get('[data-testid="readonly-mode-status"]').should(
+        'contain',
+        'READONLY',
+      );
+
+      // Set initial value for this test
+      cy.get('[data-testid="set-readonly-value"]').click();
+
+      // Get the set value
+      cy.get('[data-testid="readonly-field"]').should(
+        'have.value',
+        'new-value',
+      );
+
+      // Verify the field has readonly attribute (this is the main test)
+      cy.get('[data-testid="readonly-field"]').should('have.attr', 'readonly');
+
+      // The readonly attribute prevents user input, which is what we want to test
+      // Value should remain unchanged after the readonly mode is set
+      cy.get('[data-testid="readonly-field"]').should(
+        'have.value',
+        'new-value',
+      );
+    });
+  });
+});

--- a/docs/readonly-validation-skip.md
+++ b/docs/readonly-validation-skip.md
@@ -1,0 +1,139 @@
+# Readonly field validation skip
+
+## Purpose
+
+The readonly validation skip feature allows you to opt-in to excluding fields with the `readOnly` HTML attribute from form validation, similar to how disabled fields are handled. This provides a better user experience by preventing validation errors on fields that users cannot modify.
+
+### Benefits
+
+- Prevent validation errors on readonly fields that users cannot modify
+- Maintain consistent behavior with disabled field handling
+- Improve form usability in cases where fields are conditionally readonly
+- Reduce need for complex conditional validation logic
+
+## API Changes
+
+### New properties
+
+- `shouldSkipReadOnlyValidation`: A boolean flag that enables readonly field validation skipping when set to `true`
+
+### Type updates
+
+- `shouldSkipReadOnlyValidation` added to `useFormProps`:
+
+```typescript
+export type UseFormProps<...> = Partial<{
+    // ... existing properties
+    shouldSkipReadOnlyValidation?: boolean; // New property
+}>;
+```
+
+### Description
+
+When `shouldSkipReadOnlyValidation` is set to `true`, fields with the HTML `readOnly` attribute are excluded from all validation rules while maintaining their form integration for value updates and submission data.
+
+## Behavior
+
+When `shouldSkipReadOnlyValidation: true` is set, readonly fields with the HTML `readOnly` attribute are excluded from field validation rules. However, readonly fields still:
+
+- Update form values when changed programmatically
+- Maintain touch and dirty state tracking
+- Are included in form submission data
+- Support programmatic value updates via `setValue`
+
+## Examples
+
+### Basic readonly field
+
+```jsx
+import { useForm } from '@bombillazo/rhf-plus';
+
+function App() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    shouldSkipReadOnlyValidation: true, // Enable readonly validation skip
+    defaultValues: {
+      readonlyField: 'preset-value',
+      editableField: '',
+    },
+  });
+
+  const onSubmit = (data) => {
+    console.log(data); // Includes both readonly and editable fields
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      {/* This field will not validate even though it has required rule */}
+      <input
+        {...register('readonlyField', { required: 'This field is required' })}
+        readOnly
+      />
+      {errors.readonlyField && <span>{errors.readonlyField.message}</span>}
+
+      {/* This field will validate normally */}
+      <input
+        {...register('editableField', { required: 'This field is required' })}
+      />
+      {errors.editableField && <span>{errors.editableField.message}</span>}
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
+
+### Coexistence with disabled fields
+
+```jsx
+import { useForm } from '@bombillazo/rhf-plus';
+
+function App() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    shouldSkipReadOnlyValidation: true, // Enable readonly validation skip
+    defaultValues: {
+      readonlyField: '',
+      disabledField: '',
+      normalField: '',
+    },
+  });
+
+  return (
+    <form onSubmit={handleSubmit(console.log)}>
+      {/* Readonly field - validation skipped */}
+      <input
+        {...register('readonlyField', { required: 'Required' })}
+        readOnly
+      />
+
+      {/* Disabled field - validation skipped */}
+      <input
+        {...register('disabledField', { required: 'Required' })}
+        disabled
+      />
+
+      {/* Normal field - validation applies */}
+      <input {...register('normalField', { required: 'Required' })} />
+      {errors.normalField && <span>{errors.normalField.message}</span>}
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
+
+## Backward Compatibility
+
+This feature is fully backward compatible:
+
+- **Default behavior**: `shouldSkipReadOnlyValidation` defaults to `false`, so readonly fields are validated normally (original behavior)
+- Existing forms continue to work without any changes
+- All existing validation rules continue to work on all fields unless explicitly opted out
+- No breaking changes to existing APIs or behavior

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "files": [
       {
         "path": "./dist/index.cjs.js",
-        "maxSize": "12.0 kB"
+        "maxSize": "13.0 kB"
       }
     ]
   },

--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -68,6 +68,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
     _focusError: () => boolean | undefined;
     _disableForm: (disabled?: boolean | FieldPath<TFieldValues>[]) => void;
     _updateIsLoading: (isLoading?: boolean) => void;
+    _updateReadonlyFieldTracking: () => void;
     _subscribe: FromSubscribe<TFieldValues>;
     register: UseFormRegister<TFieldValues>;
     handleSubmit: UseFormHandleSubmit<TFieldValues, TTransformedValues>;
@@ -467,6 +468,7 @@ export type Names = {
     mount: InternalNameSet;
     unMount: InternalNameSet;
     disabled: InternalNameSet;
+    readonly: InternalNameSet;
     array: InternalNameSet;
     watch: InternalNameSet;
     focus?: InternalFieldName;
@@ -738,6 +740,7 @@ export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContex
     shouldFocusError: boolean;
     shouldUnregister: boolean;
     shouldUseNativeValidation: boolean;
+    shouldSkipReadOnlyValidation: boolean;
     progressive: boolean;
     criteriaMode: CriteriaMode;
     delayError: number;
@@ -980,7 +983,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 // Warnings were encountered during analysis:
 //
 // src/types/form.ts:36:30 - (ae-forgotten-export) The symbol "MetadataValue" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:512:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:513:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/readonly-validation.test.tsx
+++ b/src/__tests__/readonly-validation.test.tsx
@@ -1,0 +1,550 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { useForm } from '../useForm';
+
+describe('readonly field validation', () => {
+  describe('with shouldSkipReadOnlyValidation disabled (default - backwards compatible)', () => {
+    it('should validate readonly fields normally', async () => {
+      const onSubmit = jest.fn();
+      const onInvalid = jest.fn();
+
+      const App = () => {
+        const {
+          register,
+          handleSubmit,
+          formState: { errors },
+        } = useForm();
+
+        return (
+          <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+            <input
+              {...register('readonlyField', {
+                required: 'This field is required',
+              })}
+              readOnly
+              data-testid="readonly-field"
+            />
+            <input
+              {...register('normalField', {
+                required: 'This field is required',
+              })}
+              data-testid="normal-field"
+            />
+            <button type="submit">Submit</button>
+            {errors.readonlyField && (
+              <p data-testid="readonly-error">
+                {String(errors.readonlyField.message)}
+              </p>
+            )}
+            {errors.normalField && (
+              <p data-testid="normal-error">
+                {String(errors.normalField.message)}
+              </p>
+            )}
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      const readonlyField = screen.getByTestId('readonly-field');
+      const normalField = screen.getByTestId('normal-field');
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+
+      // Both fields start empty
+      expect(readonlyField).toHaveValue('');
+      expect(normalField).toHaveValue('');
+
+      // Try to submit the form
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        // Both fields should show validation errors (backwards compatible behavior)
+        expect(screen.getByTestId('normal-error')).toBeInTheDocument();
+        expect(screen.getByTestId('readonly-error')).toBeInTheDocument();
+      });
+
+      // onInvalid should be called because both fields are invalid
+      expect(onInvalid).toHaveBeenCalledWith(
+        {
+          normalField: {
+            type: 'required',
+            message: 'This field is required',
+            ref: normalField,
+          },
+          readonlyField: {
+            type: 'required',
+            message: 'This field is required',
+            ref: readonlyField,
+          },
+        },
+        expect.any(Object),
+      );
+
+      // onSubmit should not be called
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should update form values for readonly fields and still validate them', async () => {
+      let formValues: any = {};
+
+      const App = () => {
+        const {
+          register,
+          watch,
+          formState: { errors },
+        } = useForm();
+        formValues = watch();
+
+        return (
+          <div>
+            <input
+              {...register('readonlyField', {
+                required: 'This field is required',
+                minLength: { value: 5, message: 'Minimum 5 characters' },
+              })}
+              readOnly
+              data-testid="readonly-field"
+              defaultValue="test"
+            />
+            {errors.readonlyField && (
+              <p data-testid="readonly-error">
+                {String(errors.readonlyField.message)}
+              </p>
+            )}
+          </div>
+        );
+      };
+
+      render(<App />);
+
+      const readonlyField = screen.getByTestId('readonly-field');
+
+      // Check initial value
+      expect(readonlyField).toHaveValue('test');
+      expect(formValues.readonlyField).toBe('test');
+
+      // Simulate programmatic value change (e.g., by another script)
+      fireEvent.change(readonlyField, { target: { value: 'ab' } });
+
+      await waitFor(() => {
+        // Value should be updated in form state
+        expect(formValues.readonlyField).toBe('ab');
+      });
+
+      // Validation errors don't appear until validation is triggered (submission, blur, etc.)
+      // But the field is still subject to validation rules when flag is disabled
+      expect(screen.queryByTestId('readonly-error')).not.toBeInTheDocument();
+    });
+
+    it('should handle readonly fields with other validation rules properly', async () => {
+      const validate = jest.fn(() => 'Custom validation error');
+      const onSubmit = jest.fn();
+
+      const App = () => {
+        const {
+          register,
+          handleSubmit,
+          formState: { errors },
+        } = useForm();
+
+        return (
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <input
+              {...register('readonlyField', {
+                required: 'Required',
+                minLength: { value: 10, message: 'Too short' },
+                maxLength: { value: 50, message: 'Too long' },
+                pattern: { value: /^[A-Z]+$/, message: 'Must be uppercase' },
+                validate,
+              })}
+              readOnly
+              data-testid="readonly-field"
+              defaultValue="TESTVALUEOK"
+            />
+            <button type="submit">Submit</button>
+            {errors.readonlyField && (
+              <p data-testid="readonly-error">
+                {String(errors.readonlyField.message)}
+              </p>
+            )}
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+
+      // Submit the form
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        // Custom validation function SHOULD be called for readonly fields when flag is disabled
+        expect(validate).toHaveBeenCalledWith('TESTVALUEOK', {
+          readonlyField: 'TESTVALUEOK',
+        });
+        // Validation errors SHOULD appear
+        expect(screen.getByTestId('readonly-error')).toBeInTheDocument();
+      });
+
+      // Form should NOT submit since readonly field validation failed
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should still update touched and dirty state for readonly fields', async () => {
+      let capturedFormState: any = {};
+
+      const App = () => {
+        const { register, formState } = useForm();
+        capturedFormState = formState;
+
+        return (
+          <div>
+            <input
+              {...register('readonlyField')}
+              readOnly
+              data-testid="readonly-field"
+            />
+          </div>
+        );
+      };
+
+      render(<App />);
+
+      const readonlyField = screen.getByTestId('readonly-field');
+
+      // Initially not touched or dirty
+      expect(capturedFormState.touchedFields.readonlyField).toBeFalsy();
+      expect(capturedFormState.dirtyFields.readonlyField).toBeFalsy();
+
+      // Change the value
+      fireEvent.change(readonlyField, { target: { value: 'test' } });
+
+      await waitFor(() => {
+        // Should be marked as dirty
+        expect(capturedFormState.dirtyFields.readonlyField).toBeTruthy();
+      });
+
+      // Blur the field
+      fireEvent.blur(readonlyField);
+
+      await waitFor(() => {
+        // Should be marked as touched
+        expect(capturedFormState.touchedFields.readonlyField).toBeTruthy();
+      });
+    });
+
+    it('should not interfere with disabled field behavior', async () => {
+      const onSubmit = jest.fn();
+      const onInvalid = jest.fn();
+
+      const App = () => {
+        const {
+          register,
+          handleSubmit,
+          formState: { errors },
+        } = useForm();
+
+        return (
+          <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+            <input
+              {...register('readonlyField', { required: 'Required' })}
+              readOnly
+              data-testid="readonly-field"
+            />
+            <input
+              {...register('disabledField', {
+                required: 'Required',
+                disabled: true,
+              })}
+              data-testid="disabled-field"
+            />
+            <button type="submit">Submit</button>
+            {errors.readonlyField && (
+              <p data-testid="readonly-error">
+                {String(errors.readonlyField.message)}
+              </p>
+            )}
+            {errors.disabledField && (
+              <p data-testid="disabled-error">
+                {String(errors.disabledField.message)}
+              </p>
+            )}
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+
+      // Submit the form
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        // Readonly field SHOULD show validation error when flag is disabled
+        expect(screen.getByTestId('readonly-error')).toBeInTheDocument();
+        // Disabled field should NOT show validation error (always skipped)
+        expect(screen.queryByTestId('disabled-error')).not.toBeInTheDocument();
+      });
+
+      // Form should NOT submit since readonly field validation failed
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(onInvalid).toHaveBeenCalled();
+    });
+  });
+
+  describe('with shouldSkipReadOnlyValidation enabled (new behavior)', () => {
+    it('should skip validation for readonly fields', async () => {
+      const onSubmit = jest.fn();
+      const onInvalid = jest.fn();
+
+      const App = () => {
+        const {
+          register,
+          handleSubmit,
+          formState: { errors },
+        } = useForm({
+          shouldSkipReadOnlyValidation: true,
+        });
+
+        return (
+          <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+            <input
+              {...register('readonlyField', {
+                required: 'This field is required',
+              })}
+              readOnly
+              data-testid="readonly-field"
+            />
+            <input
+              {...register('normalField', {
+                required: 'This field is required',
+              })}
+              data-testid="normal-field"
+            />
+            <button type="submit">Submit</button>
+            {errors.readonlyField && (
+              <p data-testid="readonly-error">
+                {String(errors.readonlyField.message)}
+              </p>
+            )}
+            {errors.normalField && (
+              <p data-testid="normal-error">
+                {String(errors.normalField.message)}
+              </p>
+            )}
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      const readonlyField = screen.getByTestId('readonly-field');
+      const normalField = screen.getByTestId('normal-field');
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+
+      // Both fields start empty
+      expect(readonlyField).toHaveValue('');
+      expect(normalField).toHaveValue('');
+
+      // Try to submit the form
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        // Normal field should show validation error
+        expect(screen.getByTestId('normal-error')).toBeInTheDocument();
+        // Readonly field should NOT show validation error
+        expect(screen.queryByTestId('readonly-error')).not.toBeInTheDocument();
+      });
+
+      // onInvalid should be called because normal field is invalid
+      expect(onInvalid).toHaveBeenCalledWith(
+        {
+          normalField: {
+            type: 'required',
+            message: 'This field is required',
+            ref: normalField,
+          },
+        },
+        expect.any(Object),
+      );
+
+      // onSubmit should not be called
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should update form values for readonly fields but skip validation', async () => {
+      let formValues: any = {};
+
+      const App = () => {
+        const {
+          register,
+          watch,
+          formState: { errors },
+        } = useForm({
+          shouldSkipReadOnlyValidation: true,
+        });
+        formValues = watch();
+
+        return (
+          <div>
+            <input
+              {...register('readonlyField', {
+                required: 'This field is required',
+                minLength: { value: 5, message: 'Minimum 5 characters' },
+              })}
+              readOnly
+              data-testid="readonly-field"
+              defaultValue="test"
+            />
+            {errors.readonlyField && (
+              <p data-testid="readonly-error">
+                {String(errors.readonlyField.message)}
+              </p>
+            )}
+          </div>
+        );
+      };
+
+      render(<App />);
+
+      const readonlyField = screen.getByTestId('readonly-field');
+
+      // Check initial value
+      expect(readonlyField).toHaveValue('test');
+      expect(formValues.readonlyField).toBe('test');
+
+      // Simulate programmatic value change (e.g., by another script)
+      fireEvent.change(readonlyField, { target: { value: 'ab' } });
+
+      await waitFor(() => {
+        // Value should be updated in form state
+        expect(formValues.readonlyField).toBe('ab');
+      });
+
+      // No validation errors should appear even though value is less than minLength
+      expect(screen.queryByTestId('readonly-error')).not.toBeInTheDocument();
+    });
+
+    it('should handle readonly fields with all validation rules properly', async () => {
+      const validate = jest.fn(() => 'Custom validation error');
+      const onSubmit = jest.fn();
+
+      const App = () => {
+        const {
+          register,
+          handleSubmit,
+          formState: { errors },
+        } = useForm({
+          shouldSkipReadOnlyValidation: true,
+        });
+
+        return (
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <input
+              {...register('readonlyField', {
+                required: 'Required',
+                minLength: { value: 10, message: 'Too short' },
+                maxLength: { value: 50, message: 'Too long' },
+                pattern: { value: /^[A-Z]+$/, message: 'Must be uppercase' },
+                validate,
+              })}
+              readOnly
+              data-testid="readonly-field"
+              defaultValue="test"
+            />
+            <button type="submit">Submit</button>
+            {errors.readonlyField && (
+              <p data-testid="readonly-error">
+                {String(errors.readonlyField.message)}
+              </p>
+            )}
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+
+      // Submit the form
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        // Custom validation function should NOT be called for readonly fields
+        expect(validate).not.toHaveBeenCalled();
+        // No validation errors should appear
+        expect(screen.queryByTestId('readonly-error')).not.toBeInTheDocument();
+      });
+
+      // Form should submit successfully since readonly field validation is skipped
+      expect(onSubmit).toHaveBeenCalledWith(
+        { readonlyField: 'test' },
+        expect.any(Object),
+      );
+    });
+
+    it('should not interfere with disabled field behavior', async () => {
+      const onSubmit = jest.fn();
+      const onInvalid = jest.fn();
+
+      const App = () => {
+        const {
+          register,
+          handleSubmit,
+          formState: { errors },
+        } = useForm({
+          shouldSkipReadOnlyValidation: true,
+        });
+
+        return (
+          <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+            <input
+              {...register('readonlyField', { required: 'Required' })}
+              readOnly
+              data-testid="readonly-field"
+            />
+            <input
+              {...register('disabledField', {
+                required: 'Required',
+                disabled: true,
+              })}
+              data-testid="disabled-field"
+            />
+            <button type="submit">Submit</button>
+            {errors.readonlyField && (
+              <p data-testid="readonly-error">
+                {String(errors.readonlyField.message)}
+              </p>
+            )}
+            {errors.disabledField && (
+              <p data-testid="disabled-error">
+                {String(errors.disabledField.message)}
+              </p>
+            )}
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+
+      // Submit the form
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        // Neither readonly nor disabled fields should show validation errors
+        expect(screen.queryByTestId('readonly-error')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('disabled-error')).not.toBeInTheDocument();
+      });
+
+      // Form should submit successfully since both fields skip validation
+      expect(onSubmit).toHaveBeenCalled();
+      expect(onInvalid).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -33,7 +33,7 @@ import getValueAndMessage from './getValueAndMessage';
 
 export default async <T extends FieldValues>(
   field: Field,
-  disabledFieldNames: InternalNameSet,
+  skippedFieldNames: InternalNameSet,
   formValues: T,
   validateAllFieldCriteria: boolean,
   shouldUseNativeValidation?: boolean,
@@ -54,10 +54,11 @@ export default async <T extends FieldValues>(
     mount,
   } = field._f;
   const inputValue: NativeFieldValue = get(formValues, name);
-  if (!mount || disabledFieldNames.has(name)) {
+  if (!mount || skippedFieldNames.has(name)) {
     return {};
   }
   const inputRef: HTMLInputElement = refs ? refs[0] : (ref as HTMLInputElement);
+
   const setCustomValidity = (message?: Message | boolean) => {
     if (shouldUseNativeValidation && inputRef.reportValidity) {
       if (isBoolean(message)) {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -130,6 +130,7 @@ export type UseFormProps<
   shouldFocusError: boolean;
   shouldUnregister: boolean;
   shouldUseNativeValidation: boolean;
+  shouldSkipReadOnlyValidation: boolean;
   progressive: boolean;
   criteriaMode: CriteriaMode;
   delayError: number;
@@ -848,6 +849,7 @@ export type Names = {
   mount: InternalNameSet;
   unMount: InternalNameSet;
   disabled: InternalNameSet;
+  readonly: InternalNameSet;
   array: InternalNameSet;
   watch: InternalNameSet;
   focus?: InternalFieldName;
@@ -925,6 +927,7 @@ export type Control<
   _focusError: () => boolean | undefined;
   _disableForm: (disabled?: boolean | FieldPath<TFieldValues>[]) => void;
   _updateIsLoading: (isLoading?: boolean) => void;
+  _updateReadonlyFieldTracking: () => void;
   _subscribe: FromSubscribe<TFieldValues>;
   register: UseFormRegister<TFieldValues>;
   handleSubmit: UseFormHandleSubmit<TFieldValues, TTransformedValues>;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -138,6 +138,12 @@ export function useForm<
     [control, props.disabled],
   );
 
+  // Handle shouldSkipReadOnlyValidation flag changes
+  React.useEffect(() => {
+    // Re-evaluate readonly field tracking when the flag changes
+    control._updateReadonlyFieldTracking();
+  }, [control, props.shouldSkipReadOnlyValidation]);
+
   React.useEffect(() => {
     control._updateIsLoading(props.isLoading);
   }, [control, props.isLoading]);


### PR DESCRIPTION
Resolves #63

## Summary

- Add backwards-compatible `shouldSkipReadOnlyValidation` flag to `UseFormProps` that defaults to `false`
- Implement dynamic readonly field tracking system that detects HTML `readOnly` attributes at registration and runtime
- Skip all validation rules (required, pattern, minLength, custom) for readonly fields when flag is enabled
- Maintain full form integration for readonly fields including value updates, touch/dirty state, and submission data