### PR TITLE
Sync to v7.72.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,8 +25,8 @@ body:
     attributes:
       value: |
         V7
-        - [JS](https://codesandbox.io/s/great-paper-deove) Template
-        - [TS](https://codesandbox.io/s/eager-sun-jt4df) Template
+        - [JS](https://codesandbox.io/p/sandbox/react-hook-form-v7-js-kn8g63) Template
+        - [TS](https://codesandbox.io/p/sandbox/happy-rgb-kps3dv) Template
 
         V6
         - [JS](https://codesandbox.io/s/mystifying-keller-5jwf5) Template

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "files": [
       {
         "path": "./dist/index.cjs.js",
-        "maxSize": "11.25 kB"
+        "maxSize": "12.5 kB"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form",
   "description": "Performant, flexible and extensible forms library for React Hooks",
-  "version": "7.71.2",
+  "version": "7.72.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.mjs",
   "umd:main": "dist/index.umd.js",

--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -227,6 +227,7 @@ export type FieldError = {
 // @public (undocumented)
 export type FieldErrors<T extends FieldValues = FieldValues> = Partial<FieldValues extends IsAny<FieldValues> ? any : FieldErrorsImpl<DeepRequired<T>>> & {
     root?: Record<string, GlobalError> & GlobalError;
+    form?: GlobalError;
 };
 
 // @public (undocumented)
@@ -357,6 +358,12 @@ export type FormSubmitHandler<TTransformedValues> = (payload: {
     formDataJson: string;
     method?: 'post' | 'put' | 'delete';
 }) => unknown | Promise<unknown>;
+
+// @public (undocumented)
+export type FormValidateResult<T> = Partial<Record<keyof T, {
+    message: Message | Message[] | boolean | undefined;
+    type: string;
+}>> | string | boolean;
 
 // @public (undocumented)
 export type FromSubscribe<TFieldValues extends FieldValues> = <TFieldNames extends readonly FieldPath<TFieldValues>[]>(payload: {
@@ -696,7 +703,7 @@ export type UseFieldArrayUpdate<TFieldValues extends FieldValues, TFieldArrayNam
 export function useForm<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues>(props?: UseFormProps<TFieldValues, TContext, TTransformedValues>): UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
 // @public
-export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[] | `root.${string}` | 'root') => void;
+export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[] | `root.${string}` | 'root' | 'form' | `form.${string}`) => void;
 
 // @public
 export const useFormContext: <TFieldValues extends FieldValues, TContext = any, TTransformedValues = TFieldValues>() => UseFormReturn<TFieldValues, TContext, TTransformedValues>;
@@ -738,6 +745,7 @@ export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContex
     criteriaMode: CriteriaMode;
     delayError: number;
     formControl?: Omit<UseFormReturn<TFieldValues, TContext, TTransformedValues>, 'formState'>;
+    validate: ValidateForm<TFieldValues>;
 }>;
 
 // @public
@@ -787,7 +795,7 @@ export type UseFormReturn<TFieldValues extends FieldValues = FieldValues, TConte
 };
 
 // @public
-export type UseFormSetError<TFieldValues extends FieldValues> = (name: FieldPath<TFieldValues> | `root.${string}` | 'root', error: ErrorOption, options?: {
+export type UseFormSetError<TFieldValues extends FieldValues> = (name: FieldPath<TFieldValues> | `root.${string}` | 'root' | 'form' | `form.${string}`, error: ErrorOption, options?: {
     shouldFocus: boolean;
 }) => void;
 
@@ -918,6 +926,19 @@ export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
 export type Validate<TFieldValue, TFormValues> = (value: TFieldValue, formValues: TFormValues) => ValidateResult | Promise<ValidateResult>;
 
 // @public (undocumented)
+export type ValidateForm<TFormValues extends FieldValues, TFieldName extends FieldPath<TFormValues> = FieldPath<TFormValues>> = (props: {
+    formValues: TFormValues;
+    formState: FormState<TFormValues>;
+    eventType?: ValidateFormEventType;
+    name?: TFieldName | TFieldName[];
+}) => FormValidateResult<TFormValues> | Promise<FormValidateResult<TFormValues>>;
+
+// Warning: (ae-forgotten-export) The symbol "EVENTS" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type ValidateFormEventType = (typeof EVENTS)[keyof typeof EVENTS];
+
+// @public (undocumented)
 export type ValidateResult = Message | Message[] | boolean | undefined;
 
 // Warning: (ae-forgotten-export) The symbol "VALIDATION_MODE" needs to be exported by the entry point index.d.ts
@@ -985,7 +1006,7 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:506:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:507:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -514,6 +514,8 @@ export type ReadFormState = {
     [K in keyof FormStateProxy]: boolean | 'all';
 } & {
     values?: boolean;
+    isSubmitted?: boolean | 'all';
+    submitCount?: boolean | 'all';
 };
 
 // @public (undocumented)
@@ -1006,7 +1008,7 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:507:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:509:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/useFieldArray/append.test.tsx
+++ b/src/__tests__/useFieldArray/append.test.tsx
@@ -86,6 +86,56 @@ describe('append', () => {
     });
   });
 
+  it('should not mark unrelated fields as dirty when appending to field array', async () => {
+    let dirtyInputs = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyInputs = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ value: 'new' })}>
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(dirtyInputs).toEqual({
+        items: [{ value: true }],
+      });
+    });
+  });
+
   it('should append data into the fields', () => {
     let currentFields: unknown[] = [];
     const Component = () => {

--- a/src/__tests__/useFieldArray/dirtyFields.test.tsx
+++ b/src/__tests__/useFieldArray/dirtyFields.test.tsx
@@ -1,0 +1,710 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { useFieldArray } from '../../useFieldArray';
+import { useForm } from '../../useForm';
+
+let i = 0;
+
+jest.mock('../../logic/generateId', () => () => String(i++));
+
+describe('useFieldArray dirtyFields isolation', () => {
+  beforeEach(() => {
+    i = 0;
+  });
+
+  it('should only mark items dirty when only items field array is appended', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ value: 'new' })}>
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /append/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toEqual({
+        items: [{ value: true }],
+      });
+      expect(dirtyResult).not.toHaveProperty('name');
+      expect(dirtyResult).not.toHaveProperty('age');
+    });
+  });
+
+  it('should mark both name and items dirty when both are modified', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ value: 'new' })}>
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.input(screen.getAllByRole('textbox')[0], {
+      target: { value: 'Bob' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /append/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+      expect(dirtyResult).toHaveProperty('items');
+      expect(dirtyResult).not.toHaveProperty('age');
+    });
+  });
+
+  it('should only mark items_copy dirty when only items_copy is appended (multiple field arrays)', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+        items_copy: { value: string; value2: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+          items_copy: [],
+        },
+      });
+      const itemsArray = useFieldArray({ control, name: 'items' });
+      const itemsCopyArray = useFieldArray({ control, name: 'items_copy' });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {itemsArray.fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          {itemsCopyArray.fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`items_copy.${i}.value` as const)} />
+              <input {...register(`items_copy.${i}.value2` as const)} />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() =>
+              itemsCopyArray.append({ value: 'new', value2: 'new2' })
+            }
+          >
+            appendCopy
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /appendCopy/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toEqual({
+        items_copy: [{ value: true, value2: true }],
+      });
+      expect(dirtyResult).not.toHaveProperty('name');
+      expect(dirtyResult).not.toHaveProperty('age');
+      expect(dirtyResult).not.toHaveProperty('items');
+    });
+  });
+
+  it('should mark both field arrays dirty when both are appended', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+        items_copy: { value: string; value2: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+          items_copy: [],
+        },
+      });
+      const itemsArray = useFieldArray({ control, name: 'items' });
+      const itemsCopyArray = useFieldArray({ control, name: 'items_copy' });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {itemsArray.fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          {itemsCopyArray.fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`items_copy.${i}.value` as const)} />
+              <input {...register(`items_copy.${i}.value2` as const)} />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => itemsArray.append({ value: 'item1' })}
+          >
+            appendItems
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              itemsCopyArray.append({ value: 'copy1', value2: 'copy2' })
+            }
+          >
+            appendCopy
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /appendItems/ }));
+    fireEvent.click(screen.getByRole('button', { name: /appendCopy/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('items');
+      expect(dirtyResult).toHaveProperty('items_copy');
+      expect(dirtyResult).not.toHaveProperty('name');
+      expect(dirtyResult).not.toHaveProperty('age');
+    });
+  });
+
+  it('should mark name and items_copy dirty when both are modified, leaving age and items clean', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+        items_copy: { value: string; value2: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+          items_copy: [],
+        },
+      });
+      const itemsArray = useFieldArray({ control, name: 'items' });
+      const itemsCopyArray = useFieldArray({ control, name: 'items_copy' });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} data-testid="name" />
+          <input {...register('age')} />
+          {itemsArray.fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          {itemsCopyArray.fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`items_copy.${i}.value` as const)} />
+              <input {...register(`items_copy.${i}.value2` as const)} />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() =>
+              itemsCopyArray.append({ value: 'copy1', value2: 'copy2' })
+            }
+          >
+            appendCopy
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.input(screen.getByTestId('name'), {
+      target: { value: 'Alice' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /appendCopy/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+      expect(dirtyResult).toHaveProperty('items_copy');
+      expect(dirtyResult).not.toHaveProperty('age');
+      expect(dirtyResult).not.toHaveProperty('items');
+    });
+  });
+
+  it('should not mark unrelated fields dirty with nested field array path', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        nonusservices: {
+          VATFiling_list: { id: string; value: string }[];
+        };
+      }>({
+        defaultValues: {
+          name: 'John Doe',
+          age: 30,
+          nonusservices: {
+            VATFiling_list: [{ id: '1', value: 'Item 1' }],
+          },
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'nonusservices.VATFiling_list',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input
+                {...register(`nonusservices.VATFiling_list.${i}.id` as const)}
+              />
+              <input
+                {...register(
+                  `nonusservices.VATFiling_list.${i}.value` as const,
+                )}
+              />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => append({ id: '2', value: 'Item 2' })}
+          >
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /append/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('name');
+      expect(dirtyResult).not.toHaveProperty('age');
+      expect(dirtyResult).toHaveProperty('nonusservices');
+    });
+  });
+
+  it('should not mark unrelated fields dirty after remove operation', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        title: string;
+        description: string;
+        tags: { label: string }[];
+      }>({
+        defaultValues: {
+          title: 'My Post',
+          description: 'Some description',
+          tags: [{ label: 'react' }, { label: 'typescript' }],
+        },
+      });
+      const { fields, remove } = useFieldArray({
+        control,
+        name: 'tags',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('title')} />
+          <input {...register('description')} />
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`tags.${i}.label` as const)} />
+              <button type="button" onClick={() => remove(i)}>
+                remove{i}
+              </button>
+            </div>
+          ))}
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /remove0/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('title');
+      expect(dirtyResult).not.toHaveProperty('description');
+      expect(dirtyResult).toHaveProperty('tags');
+    });
+  });
+
+  it('should preserve name dirty state after append then remove reverts array', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          items: [{ value: 'original' }],
+        },
+      });
+      const { fields, append, remove } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} data-testid="name" />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ value: 'new' })}>
+            append
+          </button>
+          <button type="button" onClick={() => remove(fields.length - 1)}>
+            removeLast
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.input(screen.getByTestId('name'), {
+      target: { value: 'Changed' },
+    });
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /append/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+      expect(dirtyResult).toHaveProperty('items');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /removeLast/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+    });
+  });
+
+  it('should not pollute unrelated fields after multiple appends', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        email: string;
+        phone: string;
+        addresses: { street: string; city: string }[];
+      }>({
+        defaultValues: {
+          email: 'john@example.com',
+          phone: '123-456',
+          addresses: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'addresses',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('email')} />
+          <input {...register('phone')} />
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`addresses.${i}.street` as const)} />
+              <input {...register(`addresses.${i}.city` as const)} />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => append({ street: '', city: '' })}
+          >
+            addAddress
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /addAddress/ }));
+    fireEvent.click(screen.getByRole('button', { name: /addAddress/ }));
+    fireEvent.click(screen.getByRole('button', { name: /addAddress/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('email');
+      expect(dirtyResult).not.toHaveProperty('phone');
+      expect(dirtyResult).toHaveProperty('addresses');
+      expect((dirtyResult as any).addresses).toHaveLength(3);
+    });
+  });
+
+  it('should isolate dirty state in large forms with many fields', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        firstName: string;
+        lastName: string;
+        email: string;
+        phone: string;
+        company: string;
+        todos: { task: string }[];
+      }>({
+        defaultValues: {
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'john@test.com',
+          phone: '555-1234',
+          company: 'Acme',
+          todos: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'todos',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('firstName')} />
+          <input {...register('lastName')} />
+          <input {...register('email')} />
+          <input {...register('phone')} />
+          <input {...register('company')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`todos.${i}.task` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ task: 'New todo' })}>
+            addTodo
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /addTodo/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('firstName');
+      expect(dirtyResult).not.toHaveProperty('lastName');
+      expect(dirtyResult).not.toHaveProperty('email');
+      expect(dirtyResult).not.toHaveProperty('phone');
+      expect(dirtyResult).not.toHaveProperty('company');
+      expect(dirtyResult).toHaveProperty('todos');
+    });
+  });
+
+  it('should only update root branch when nested useFieldArray with indexed name is appended', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        title: string;
+        test: {
+          firstName: string;
+          lastName: string;
+          keyValue: { name: string }[];
+        }[];
+      }>({
+        defaultValues: {
+          title: 'My Form',
+          test: [
+            {
+              firstName: 'Bill',
+              lastName: 'Luo',
+              keyValue: [{ name: '1a' }],
+            },
+          ],
+        },
+      });
+      const { fields: testFields } = useFieldArray({
+        control,
+        name: 'test',
+      });
+      const {
+        fields: keyValueFields,
+        append,
+        remove,
+      } = useFieldArray({
+        control,
+        name: 'test.0.keyValue',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('title')} />
+          {testFields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`test.${i}.firstName` as const)} />
+              <input {...register(`test.${i}.lastName` as const)} />
+            </div>
+          ))}
+          {keyValueFields.map((field, i) => (
+            <input
+              key={field.id}
+              {...register(`test.0.keyValue.${i}.name` as const)}
+            />
+          ))}
+          <button type="button" onClick={() => append({ name: 'new' })}>
+            nestAppend
+          </button>
+          <button
+            type="button"
+            onClick={() => remove(keyValueFields.length - 1)}
+          >
+            nestRemove
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /nestAppend/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('title');
+      expect(dirtyResult).toHaveProperty('test');
+      const testArray = (dirtyResult as any).test;
+      expect(testArray[0]).toHaveProperty('keyValue');
+      expect(testArray[0].keyValue).toEqual([{ name: false }, { name: true }]);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /nestRemove/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('title');
+    });
+  });
+});

--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -84,6 +84,54 @@ describe('remove', () => {
     expect(formState.isDirty).toBeFalsy();
   });
 
+  it('should not mark unrelated fields as dirty when removing from field array', async () => {
+    let dirtyInputs = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          items: [{ value: 'first' }, { value: 'second' }],
+        },
+      });
+      const { fields, remove } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyInputs = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`items.${i}.value` as const)} />
+              <button type="button" onClick={() => remove(i)}>
+                remove{i}
+              </button>
+            </div>
+          ))}
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /remove0/i }));
+
+    await waitFor(() => {
+      expect(dirtyInputs).not.toHaveProperty('name');
+      expect(dirtyInputs).toHaveProperty('items');
+    });
+  });
+
   it('should update isValid formState when item removed', async () => {
     let formState: any;
     const Component = () => {

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -2764,6 +2764,7 @@ describe('useForm', () => {
         </div>
       );
     }
+
     it('formState.defaultValues and useFormState().defaultValues should be equal after reset', () => {
       render(<App />);
 
@@ -2774,6 +2775,51 @@ describe('useForm', () => {
       const reactValue = screen.getByTestId('react').textContent;
       expect(screen.getByTestId('form').textContent).toBe(reactValue);
       expect(screen.getByTestId('state').textContent).toBe(reactValue);
+    });
+  });
+
+  describe('form level validation', () => {
+    it('should return form level error', async () => {
+      const App = () => {
+        const {
+          register,
+          formState: { errors },
+          handleSubmit,
+        } = useForm({
+          validate: ({ formValues }) => {
+            if (formValues.firstName) {
+              return true;
+            }
+
+            return 'required';
+          },
+          defaultValues: {
+            firstName: '',
+          },
+        });
+
+        return (
+          <form onSubmit={handleSubmit(() => {})}>
+            <input {...register('firstName')} />
+            <p>{errors.form?.message}</p>
+            <button>submit</button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() => expect(screen.getByText('required')).toBeVisible());
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'test' },
+      });
+
+      await waitFor(() =>
+        expect(screen.queryByText('required')).not.toBeInTheDocument(),
+      );
     });
   });
 });

--- a/src/__tests__/useForm/subscribe.test.tsx
+++ b/src/__tests__/useForm/subscribe.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import type { UseFormSubscribe } from '../../types';
 import { useForm } from '../../useForm';
@@ -119,5 +119,42 @@ describe('subscribe', () => {
     });
 
     expect(callbackFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should allow subscribing to submit state updates', async () => {
+    const callbackFn = jest.fn();
+
+    const App = () => {
+      const { handleSubmit, subscribe } = useForm();
+
+      React.useEffect(() => {
+        return subscribe({
+          formState: {
+            isSubmitted: true,
+            submitCount: true,
+          },
+          callback: callbackFn,
+        });
+      }, [subscribe]);
+
+      return (
+        <form onSubmit={handleSubmit(() => undefined)}>
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(callbackFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isSubmitted: true,
+          submitCount: 1,
+        }),
+      ),
+    );
   });
 });

--- a/src/__typetest__/errors.test-d.ts
+++ b/src/__typetest__/errors.test-d.ts
@@ -28,6 +28,7 @@ import { _ } from './__fixtures__';
         >;
       } & {
         root?: Record<string, GlobalError> & GlobalError;
+        form?: GlobalError;
       }
     >(actual);
   }
@@ -55,6 +56,7 @@ import { _ } from './__fixtures__';
         >;
       } & {
         root?: Record<string, GlobalError> & GlobalError;
+        form?: GlobalError;
       }
     >(actual);
   }

--- a/src/__typetest__/form.test-d.ts
+++ b/src/__typetest__/form.test-d.ts
@@ -130,6 +130,26 @@ const schema = z.object({
   }
 }
 
+/** {@link UseFormSubscribe} */ {
+  /** it should allow subscribing to submit state fields */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const { subscribe } = useForm<{
+      test: string;
+    }>();
+
+    subscribe({
+      formState: {
+        isSubmitted: true,
+        submitCount: true,
+      },
+      callback: (state) => {
+        expectType<boolean | undefined>(state.isSubmitted);
+        expectType<number | undefined>(state.submitCount);
+      },
+    });
+  }
+}
+
 export function mockZodResolver<Input extends FieldValues, Context, Output>(
   schema: z.ZodSchema<Output, any, Input>,
   schemaOptions?: Partial<z.ParseParams>,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,9 @@ export const EVENTS = {
   BLUR: 'blur',
   FOCUS_OUT: 'focusout',
   CHANGE: 'change',
+  SUBMIT: 'submit',
+  TRIGGER: 'trigger',
+  VALID: 'valid',
 } as const;
 
 export const VALIDATION_MODE = {
@@ -21,3 +24,7 @@ export const INPUT_VALIDATION_RULES = {
   required: 'required',
   validate: 'validate',
 } as const;
+
+export const FORM_ERROR_TYPE = 'form';
+
+export const ROOT_ERROR_TYPE = 'root';

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -81,6 +81,7 @@ import getDirtyFields from './getDirtyFields';
 import getEventValue from './getEventValue';
 import getFieldValue from './getFieldValue';
 import getFieldValueAs from './getFieldValueAs';
+import getNodeParentName from './getNodeParentName';
 import getResolverOptions from './getResolverOptions';
 import getRuleValue from './getRuleValue';
 import getValidationModes from './getValidationModes';
@@ -286,7 +287,9 @@ export function createFormControl<
       }
 
       if (_proxyFormState.dirtyFields || _proxySubscribeFormState.dirtyFields) {
-        _formState.dirtyFields = getDirtyFields(_defaultValues, _formValues);
+        const fullDirtyFields = getDirtyFields(_defaultValues, _formValues);
+        const rootName = getNodeParentName(name);
+        set(_formState.dirtyFields, rootName, get(fullDirtyFields, rootName));
       }
 
       _subjects.state.next({

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -595,7 +595,7 @@ export function createFormControl<
           if (fieldError[_f.name]) {
             context.valid = false;
 
-            if (onlyCheckValid || props.shouldUseNativeValidation) {
+            if (onlyCheckValid) {
               break;
             }
           }
@@ -610,6 +610,10 @@ export function createFormControl<
                   )
                 : set(_formState.errors, _f.name, fieldError[_f.name])
               : unset(_formState.errors, _f.name));
+
+          if (props.shouldUseNativeValidation && fieldError[_f.name]) {
+            break;
+          }
         }
 
         !isEmptyObject(fieldValue) &&

--- a/src/logic/updateFieldArrayRootError.ts
+++ b/src/logic/updateFieldArrayRootError.ts
@@ -1,3 +1,4 @@
+import { ROOT_ERROR_TYPE } from '../constants';
 import type {
   FieldError,
   FieldErrors,
@@ -14,7 +15,7 @@ export default <T extends FieldValues = FieldValues>(
   name: InternalFieldName,
 ): FieldErrors<T> => {
   const fieldArrayErrors = convertToArrayPayload(get(errors, name));
-  set(fieldArrayErrors, 'root', error[name]);
+  set(fieldArrayErrors, ROOT_ERROR_TYPE, error[name]);
   set(errors, name, fieldArrayErrors);
   return errors;
 };

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -51,6 +51,7 @@ export type FieldErrors<T extends FieldValues = FieldValues> = Partial<
     : FieldErrorsImpl<DeepRequired<T>>
 > & {
   root?: Record<string, GlobalError> & GlobalError;
+  form?: GlobalError;
 };
 
 export type InternalFieldErrors = Partial<

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -26,7 +26,7 @@ import type {
   DeepPartialSkipArrayKey,
   Noop,
 } from './utils';
-import type { RegisterOptions } from './validator';
+import type { RegisterOptions, ValidateForm } from './validator';
 
 declare const $NestedValue: unique symbol;
 
@@ -131,6 +131,7 @@ export type UseFormProps<
     UseFormReturn<TFieldValues, TContext, TTransformedValues>,
     'formState'
   >;
+  validate: ValidateForm<TFieldValues>;
 }>;
 
 export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<
@@ -563,7 +564,9 @@ export type UseFormClearErrors<TFieldValues extends FieldValues> = (
     | FieldPath<TFieldValues>[]
     | readonly FieldPath<TFieldValues>[]
     | `root.${string}`
-    | 'root',
+    | 'root'
+    | 'form'
+    | `form.${string}`,
 ) => void;
 
 /**
@@ -625,7 +628,12 @@ export type UseFormSetValue<TFieldValues extends FieldValues> = <
  * ```
  */
 export type UseFormSetError<TFieldValues extends FieldValues> = (
-  name: FieldPath<TFieldValues> | `root.${string}` | 'root',
+  name:
+    | FieldPath<TFieldValues>
+    | `root.${string}`
+    | 'root'
+    | 'form'
+    | `form.${string}`,
   error: ErrorOption,
   options?: {
     shouldFocus: boolean;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -151,6 +151,8 @@ export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
 
 export type ReadFormState = { [K in keyof FormStateProxy]: boolean | 'all' } & {
   values?: boolean;
+  isSubmitted?: boolean | 'all';
+  submitCount?: boolean | 'all';
 };
 
 export type FormState<TFieldValues extends FieldValues> = {

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -1,7 +1,8 @@
-import type { INPUT_VALIDATION_RULES } from '../constants';
+import type { EVENTS, INPUT_VALIDATION_RULES } from '../constants';
 
 import type { Message } from './errors';
 import type { FieldValues } from './fields';
+import type { FormState } from './form';
 import type { FieldPath, FieldPathValue } from './path';
 
 export type ValidationValue = boolean | number | string | RegExp;
@@ -19,10 +20,37 @@ export type ValidationValueMessage<
 
 export type ValidateResult = Message | Message[] | boolean | undefined;
 
+export type FormValidateResult<T> =
+  | Partial<
+      Record<
+        keyof T,
+        {
+          message: Message | Message[] | boolean | undefined;
+          type: string;
+        }
+      >
+    >
+  | string
+  | boolean;
+
 export type Validate<TFieldValue, TFormValues> = (
   value: TFieldValue,
   formValues: TFormValues,
 ) => ValidateResult | Promise<ValidateResult>;
+
+export type ValidateFormEventType = (typeof EVENTS)[keyof typeof EVENTS];
+
+export type ValidateForm<
+  TFormValues extends FieldValues,
+  TFieldName extends FieldPath<TFormValues> = FieldPath<TFormValues>,
+> = (props: {
+  formValues: TFormValues;
+  formState: FormState<TFormValues>;
+  eventType?: ValidateFormEventType;
+  name?: TFieldName | TFieldName[];
+}) =>
+  | FormValidateResult<TFormValues>
+  | Promise<FormValidateResult<TFormValues>>;
 
 export type RegisterOptions<
   TFieldValues extends FieldValues = FieldValues,


### PR DESCRIPTION
Resolves #98

## Summary

- Sync with upstream React Hook Form v7.72.0
- Adds form-level validation (`validate` option in `useForm`)
- New field array dirty fields tests
- Preserves all RHF+ custom features (metadata, isLoading, id)